### PR TITLE
Feature/breadcrumb classname

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   },
   "dependencies": {
     "babel-runtime": "^6.5.0",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.6.0"
   },
   "main": "lib/index.js",
   "engines": {

--- a/src/Breadcrumb.js
+++ b/src/Breadcrumb.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 export default class Breadcrumb extends React.Component {

--- a/src/Breadcrumb.js
+++ b/src/Breadcrumb.js
@@ -142,8 +142,8 @@ export default class Breadcrumb extends React.Component {
   render() {
     const { className } = this.props;
     const classNameParent = classNames(
-      'Breadcrumb',
       {
+        Breadcrumb: !className,
         [className]: !!className,
       }
     );

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -71,9 +71,12 @@ describe('Render and className', () => {
     expect(wrapper).to.have.exactly(2).descendants('.Breadcrumb-path');
     expect(wrapper).to.have.exactly(1).descendants('.Breadcrumb-separator');
   });
-  it('Check if we send a className prop the parent div have this class', () => {
-    const wrapper = getBreadcrumb('/check/path', () => {}, 'ClassTest');
+  it('Check if the parent has the default class when className prop is not set', () => {
+    const wrapper = getBreadcrumb('/check/path', () => {});
     expect(wrapper).to.have.className('Breadcrumb');
+  });
+  it('Check if the parent has the class we passed using the className prop', () => {
+    const wrapper = getBreadcrumb('/check/path', () => {}, 'ClassTest');
     expect(wrapper).to.have.className('ClassTest');
   });
   it('Check if we send a classes prop all items receive the correct class', () => {


### PR DESCRIPTION
Allow you to set your own className without having `Breadcrumb` before yours.